### PR TITLE
Substitute import of deprecated module

### DIFF
--- a/beetsplug/goingrunning/__init__.py
+++ b/beetsplug/goingrunning/__init__.py
@@ -4,10 +4,10 @@
 
 import os
 
-from beets import mediafile
+import mediafile
 from beets.dbcore import types
 from beets.plugins import BeetsPlugin
-from beets.util.confit import ConfigSource, load_yaml
+from confuse import ConfigSource, load_yaml
 from beetsplug.goingrunning.command import GoingRunningCommand
 
 

--- a/beetsplug/goingrunning/command.py
+++ b/beetsplug/goingrunning/command.py
@@ -11,7 +11,7 @@ from beets.dbcore.db import Results
 from beets.dbcore.queryparse import parse_query_part, construct_query_part
 from beets.library import Library, Item
 from beets.ui import Subcommand, decargs
-from beets.util.confit import Subview
+from confuse import Subview
 from beetsplug.goingrunning import common
 from beetsplug.goingrunning import itemexport
 from beetsplug.goingrunning import itemorder

--- a/beetsplug/goingrunning/common.py
+++ b/beetsplug/goingrunning/common.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from beets.dbcore import types
 from beets.library import Item
-from beets.util.confit import Subview
+from confuse import Subview
 
 # Get values as: plg_ns['__PLUGIN_NAME__']
 plg_ns = {}

--- a/beetsplug/goingrunning/itemexport.py
+++ b/beetsplug/goingrunning/itemexport.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from alive_progress import alive_bar
 from beets import util
-from beets.util.confit import Subview
+from confuse import Subview
 from beetsplug.goingrunning import common
 
 

--- a/beetsplug/goingrunning/itemorder.py
+++ b/beetsplug/goingrunning/itemorder.py
@@ -6,7 +6,7 @@ from abc import ABC
 from abc import abstractmethod
 from random import uniform
 
-from beets.util.confit import Subview
+from confuse import Subview
 from beetsplug.goingrunning import common
 
 permutations = {

--- a/beetsplug/goingrunning/itempick.py
+++ b/beetsplug/goingrunning/itempick.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from random import randint
 
 from beets.library import Item
-from beets.util.confit import Subview
+from confuse import Subview
 from beetsplug.goingrunning import common
 
 pickers = {

--- a/test/functional/001_configuration_test.py
+++ b/test/functional/001_configuration_test.py
@@ -5,7 +5,7 @@
 #  License: See LICENSE.txt
 #
 
-from beets.util.confit import Subview
+from confuse import Subview
 
 from test.helper import FunctionalTestHelper, PLUGIN_NAME
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -27,7 +27,7 @@ from beets.util import (
     bytestring_path,
     displayable_path,
 )
-from beets.util.confit import Subview, Dumper, LazyConfig, ConfigSource
+from confuse import Subview, Dumper, LazyConfig, ConfigSource
 from beetsplug import goingrunning
 from beetsplug.goingrunning import common
 from six import StringIO

--- a/test/unit/003_command_test.py
+++ b/test/unit/003_command_test.py
@@ -2,7 +2,7 @@
 #  Author: Adam Jakab <adam at jakab dot pro>
 #  License: See LICENSE.txt
 from beets.library import Item
-from beets.util.confit import Subview
+from confuse import Subview
 from beetsplug.goingrunning import GoingRunningCommand
 from beetsplug.goingrunning import command
 


### PR DESCRIPTION
`beets.util.confit` is deprecated and should be replaced by `confuse`.